### PR TITLE
Add border to keys

### DIFF
--- a/Demo/KeyboardDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/KeyboardDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/Audulus/Tonic.git",
         "state": {
           "branch": "main",
-          "revision": "121693a1fbee5aeb0bf065a97cc086f2c7c95017",
+          "revision": "1ce32a88caf64d857cef720cad00c990b135f30b",
           "version": null
         }
       }

--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -55,7 +55,7 @@ public struct Keyboard<Content>: View where Content: View {
     }
 
     var isomorphicBody: some View {
-        HStack(spacing: 1) {
+        HStack(spacing: 0) {
             ForEach(pitchRange, id: \.self) { pitch in
                 KeyContainer(model: model,
                              pitch: pitch,
@@ -66,12 +66,12 @@ public struct Keyboard<Content>: View where Content: View {
                              content: content)
             }
         }
-        .frame(minWidth: 600, minHeight: 100)
+        .frame(minWidth: 100, minHeight: 100)
         .clipShape(Rectangle())
     }
 
     var pianoRollBody: some View {
-        VStack(spacing: 1) {
+        VStack(spacing: 0) {
             ForEach(pitchRange, id: \.self) { pitch in
                 KeyContainer(model: model,
                              pitch: pitch,
@@ -82,7 +82,7 @@ public struct Keyboard<Content>: View where Content: View {
                              content: content)
             }
         }
-        .frame(minWidth: 100, minHeight: 600)
+        .frame(minWidth: 100, minHeight: 100)
         .clipShape(Rectangle())
     }
 
@@ -90,7 +90,7 @@ public struct Keyboard<Content>: View where Content: View {
     var pianoBody: some View {
 
         ZStack {
-            HStack(spacing: 1) {
+            HStack(spacing: 0) {
                 ForEach(whiteKeys, id: \.self) { pitch in
                     KeyContainer(model: model,
                                  pitch: pitch,
@@ -101,7 +101,7 @@ public struct Keyboard<Content>: View where Content: View {
                 }
             }
             VStack {
-                HStack(spacing: 1) {
+                HStack(spacing: 0) {
                     ForEach(whiteKeys, id: \.self) { pitch in
                         KeyContainer(model: model,
                                      pitch: Pitch(intValue: pitch.intValue + 1),
@@ -115,7 +115,7 @@ public struct Keyboard<Content>: View where Content: View {
                 Spacer()
             }
         }
-        .frame(minWidth: 600, minHeight: 100)
+        .frame(minWidth: 100, minHeight: 100)
         .clipShape(Rectangle())
     }
 }

--- a/Sources/Keyboard/KeyboardKey.swift
+++ b/Sources/Keyboard/KeyboardKey.swift
@@ -49,6 +49,8 @@ public struct KeyboardKey: View {
                 RoundedRectangle(cornerSize: CGSize(width: minDimension(proxy.size) / 8.0,
                                                     height: minDimension(proxy.size) / 8.0))
                     .foregroundColor(keyColor)
+                    .overlay(RoundedRectangle(cornerRadius: minDimension(proxy.size) / 8.0)
+                            .strokeBorder(Color.black, lineWidth: 0.5))
                 Text(text)
                     .font(Font(.init(.system, size: minDimension(proxy.size) / 3)))
                     .foregroundColor(textColor)


### PR DESCRIPTION
This PR adds a black border to the inside of the keys and lowers the key spacing from 1 to 0 (not sure if that was needed). It also decreases the min keyboard height and width so that it will fit on iPhone portrait. 