### PR TITLE
Hide partial keys

### DIFF
--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -109,7 +109,7 @@ public struct Keyboard<Content>: View where Content: View {
                                      noteOn: noteOn,
                                      noteOff: noteOff,
                                      content: content)
-                        .opacity(blackKeyExists(for: Pitch(intValue: pitch.intValue + 1)) ? 1 : 0)
+                        .opacity(blackKeyExists(for: Pitch(intValue: pitch.intValue + 1)) && pitch.intValue < pitchRange.upperBound.intValue ? 1 : 0)
                     }
                 }
                 Spacer()


### PR DESCRIPTION
This PR visually hides the last partial black key from the pianoBody if it is not included in the pitchRange.

TODO: The hidden black key still detects gestures which may need to be addressed at some point.