### PR TITLE
Keyboard key color

### DIFF
--- a/Demo/Shared/ContentView.swift
+++ b/Demo/Shared/ContentView.swift
@@ -17,14 +17,18 @@ struct ContentView: View {
     }()
 
     @State var octave = 0
+    @State var range = 2
 
     var body: some View {
         HStack {
             Keyboard(pitchRange: Pitch(48)...Pitch(77),
                      layout: .pianoRoll).frame(width: 200)
             VStack {
-                Stepper("Octave \(octave)", onIncrement: { if octave < 7 { octave += 1 }}, onDecrement: { if octave > -1 { octave -= 1 }})
-                Keyboard(pitchRange: Note(.C, octave: octave).pitch...Note(.C, octave: octave + 2).pitch,
+                HStack {
+                    Stepper("Octave \(octave)", onIncrement: { if octave + range < 9 { octave += 1 }}, onDecrement: { if octave > -1 { octave -= 1 }})
+                    Stepper("Range \(range)", onIncrement: { if range + octave < 9 { range += 1 }}, onDecrement: { if range > 1 { range -= 1 }})
+                }
+                Keyboard(pitchRange: Note(.C, octave: octave).pitch...Note(.C, octave: octave + range).pitch,
                          noteOn: noteOn, noteOff: noteOff)
                 Keyboard(pitchRange: Pitch(12)...Pitch(84),
                          layout: .isomorphic,
@@ -34,7 +38,7 @@ struct ContentView: View {
                     KeyboardKey(pitch: pitch,
                                 isActivated: isActivated,
                                 text: pitch.note(in: .F).description,
-                                color: Color(PitchColor.newtonian[Int(pitch.pitchClass)]))
+                                pressedColor: Color(PitchColor.newtonian[Int(pitch.pitchClass)]))
                 }
                 Keyboard(latching: true, noteOn: noteOn, noteOff: noteOff) { pitch, isActivated in
                     if isActivated {

--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -56,7 +56,7 @@ public struct Keyboard<Content>: View where Content: View {
     }
 
     var isomorphicBody: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 1) {
             ForEach(pitchRange, id: \.self) { pitch in
                 KeyContainer(model: model,
                              pitch: pitch,
@@ -72,7 +72,7 @@ public struct Keyboard<Content>: View where Content: View {
     }
 
     var pianoRollBody: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: 1) {
             ForEach(pitchRange, id: \.self) { pitch in
                 KeyContainer(model: model,
                              pitch: pitch,
@@ -91,7 +91,7 @@ public struct Keyboard<Content>: View where Content: View {
     var pianoBody: some View {
 
         ZStack {
-            HStack(spacing: 0) {
+            HStack(spacing: 1) {
                 ForEach(whiteKeys, id: \.self) { pitch in
                     KeyContainer(model: model,
                                  pitch: pitch,
@@ -104,7 +104,7 @@ public struct Keyboard<Content>: View where Content: View {
 
             // Black keys.
             VStack {
-                HStack(spacing: 0) {
+                HStack(spacing: 1) {
 
                     // We lay out the black keys by adding transparent
                     // rectangles between sets of black keys.

--- a/Sources/Keyboard/KeyboardKey.swift
+++ b/Sources/Keyboard/KeyboardKey.swift
@@ -15,7 +15,10 @@ public struct KeyboardKey: View {
     public init(pitch: Pitch,
                 isActivated: Bool,
                 text: String = "unset",
-                color: Color = .red,
+                whiteKeyColor: Color = .white,
+                blackKeyColor: Color = .black,
+                pressedColor: Color = .red,
+                flatTop: Bool = false,
                 isActivatedExternally: Bool = false) {
         self.pitch = pitch
         self.isActivated = isActivated
@@ -30,25 +33,31 @@ public struct KeyboardKey: View {
         } else {
             self.text = text
         }
-        self.color = color
+        self.whiteKeyColor = whiteKeyColor
+        self.blackKeyColor = blackKeyColor
+        self.pressedColor = pressedColor
+        self.flatTop = flatTop
         self.isActivatedExternally = isActivatedExternally
     }
 
     var pitch: Pitch
     var isActivated: Bool
-    var color: Color
+    var whiteKeyColor: Color
+    var blackKeyColor: Color
+    var pressedColor: Color
+    var flatTop: Bool
     var text: String
     var isActivatedExternally: Bool
 
     var keyColor: Color {
         if isActivatedExternally || isActivated {
-            return color
+            return pressedColor
         }
-        return pitch.note(in: .C).accidental == .natural ? .white : .black
+        return pitch.note(in: .C).accidental == .natural ? whiteKeyColor : blackKeyColor
     }
 
     var textColor: Color {
-        return pitch.note(in: .C).accidental == .natural ? .black : .white
+        return pitch.note(in: .C).accidental == .natural ? blackKeyColor : whiteKeyColor
     }
 
     func minDimension(_ size: CGSize) -> CGFloat {
@@ -58,11 +67,11 @@ public struct KeyboardKey: View {
     public var body: some View {
         GeometryReader { proxy in
             ZStack(alignment: proxy.size.height > proxy.size.width ? .bottom : .trailing) {
-                RoundedRectangle(cornerSize: CGSize(width: minDimension(proxy.size) / 8.0,
-                                                    height: minDimension(proxy.size) / 8.0))
+                Rectangle()
                     .foregroundColor(keyColor)
-                    .overlay(RoundedRectangle(cornerRadius: minDimension(proxy.size) / 8.0)
-                            .strokeBorder(Color.black, lineWidth: 0.5))
+                    .padding(.top, flatTop ?minDimension(proxy.size) / 8.0 : 0)
+                    .cornerRadius(minDimension(proxy.size) / 8.0)
+                    .padding(.top, flatTop ? -minDimension(proxy.size) / 8.0 : 0)
                 Text(text)
                     .font(Font(.init(.system, size: minDimension(proxy.size) / 3)))
                     .foregroundColor(textColor)


### PR DESCRIPTION
This PR adds the ability to change the key colors, option to leave the top key corners flat, adds a range control to the demo, & adds the boarder spacing back in. 

White keys will again blend with a white backgrounds. If this is an issue, developers can add .background(.black).cornerRadius(5) to pop it off the background.

Here is an example key styling

```
//Add Custom KeyboardKey Style
                Keyboard(pitchRange: Note(.C, octave: octave).pitch...Note(.C, octave: octave + range).pitch,
                         noteOn: noteOn, noteOff: noteOff){ pitch, isActivated in
                    KeyboardKey(pitch: pitch,
                                isActivated: isActivated,
                                text: "",
                                whiteKeyColor: Color.purple,
                                blackKeyColor: Color.black,
                                pressedColor: Color.pink,
                                flatTop: true)
                }.cornerRadius(5)
```
