### PR TITLE
Add Guitar Layout

### DIFF
--- a/Demo/Shared/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Demo/Shared/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -72,6 +72,11 @@
     },
     {
       "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
       "scale" : "2x",
       "size" : "76x76"
     },

--- a/Demo/Shared/ContentView.swift
+++ b/Demo/Shared/ContentView.swift
@@ -34,8 +34,8 @@ struct ContentView: View {
                          layout: .isomorphic,
                          noteOn: noteOn, noteOff: noteOff)
                 Keyboard(pitchRange: Pitch(36)...Pitch(60),
-                         layout: .guitar,
-                         noteOn: noteOn, noteOff: noteOff, rows: 6)
+                         layout: .guitar, rowCount: 6,
+                         noteOn: noteOn, noteOff: noteOff)
                 Keyboard(pitchRange: Pitch(48)...Pitch(65),
                          layout: .isomorphic) { pitch, isActivated in
                     KeyboardKey(pitch: pitch,

--- a/Demo/Shared/ContentView.swift
+++ b/Demo/Shared/ContentView.swift
@@ -33,6 +33,9 @@ struct ContentView: View {
                 Keyboard(pitchRange: Pitch(12)...Pitch(84),
                          layout: .isomorphic,
                          noteOn: noteOn, noteOff: noteOff)
+                Keyboard(pitchRange: Pitch(24)...Pitch(64),
+                         layout: .guitar,
+                         noteOn: noteOn, noteOff: noteOff)
                 Keyboard(pitchRange: Pitch(48)...Pitch(65),
                          layout: .isomorphic) { pitch, isActivated in
                     KeyboardKey(pitch: pitch,

--- a/Demo/Shared/ContentView.swift
+++ b/Demo/Shared/ContentView.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
                          noteOn: noteOn, noteOff: noteOff)
                 Keyboard(pitchRange: Pitch(36)...Pitch(60),
                          layout: .guitar,
-                         noteOn: noteOn, noteOff: noteOff)
+                         noteOn: noteOn, noteOff: noteOff, rows: 6)
                 Keyboard(pitchRange: Pitch(48)...Pitch(65),
                          layout: .isomorphic) { pitch, isActivated in
                     KeyboardKey(pitch: pitch,

--- a/Demo/Shared/ContentView.swift
+++ b/Demo/Shared/ContentView.swift
@@ -33,7 +33,7 @@ struct ContentView: View {
                 Keyboard(pitchRange: Pitch(12)...Pitch(84),
                          layout: .isomorphic,
                          noteOn: noteOn, noteOff: noteOff)
-                Keyboard(pitchRange: Pitch(24)...Pitch(64),
+                Keyboard(pitchRange: Pitch(36)...Pitch(60),
                          layout: .guitar,
                          noteOn: noteOn, noteOff: noteOff)
                 Keyboard(pitchRange: Pitch(48)...Pitch(65),

--- a/Demo/Shared/ContentView.swift
+++ b/Demo/Shared/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
                          layout: .isomorphic,
                          noteOn: noteOn, noteOff: noteOff)
                 Keyboard(pitchRange: Pitch(36)...Pitch(60),
-                         layout: .guitar, rowCount: 6,
+                         layout: .guitar(rowCount: 6),
                          noteOn: noteOn, noteOff: noteOff)
                 Keyboard(pitchRange: Pitch(48)...Pitch(65),
                          layout: .isomorphic) { pitch, isActivated in

--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -10,6 +10,7 @@ public struct Keyboard<Content>: View where Content: View {
     var latching: Bool
     var noteOn: (Pitch) -> Void
     var noteOff: (Pitch) -> Void
+    var rows: Int
     var layout: KeyboardLayout
 
     public init(pitchRange: ClosedRange<Pitch> = (Pitch(60)...Pitch(72)),
@@ -17,12 +18,14 @@ public struct Keyboard<Content>: View where Content: View {
                 layout: KeyboardLayout = .piano,
                 noteOn: @escaping (Pitch) -> Void = { _ in },
                 noteOff: @escaping (Pitch) -> Void = { _ in },
+                rows: Int = 6,
                 @ViewBuilder content: @escaping (Pitch, Bool)->Content) {
         self.pitchRange = pitchRange
         self.latching = latching
         self.layout = layout
         self.noteOn = noteOn
         self.noteOff = noteOff
+        self.rows = rows
         self.content = content
     }
 
@@ -45,6 +48,7 @@ public struct Keyboard<Content>: View where Content: View {
             switch layout {
             case .piano:      pianoBody
             case .isomorphic: isomorphicBody
+            case .guitar: guitarBody
             case .pianoRoll:  pianoRollBody
             }
         }.onPreferenceChange(TouchLocationsKey.self) { touchLocations in
@@ -62,6 +66,27 @@ public struct Keyboard<Content>: View where Content: View {
                              latching: latching,
                              layout: .isomorphic,
                              content: content)
+            }
+        }
+        .frame(minWidth: 100, minHeight: 100)
+        .clipShape(Rectangle())
+    }
+    
+    var guitarBody: some View {
+        //Loop through the keys and add rows (strings)
+        //Each row has a 5 note offset tuning them to 4ths
+        //The pitchRange is for the lowest row (string)
+        HStack(spacing: 0) {
+            ForEach(pitchRange, id: \.self) { pitch in
+                VStack(spacing: 0){
+                    ForEach(0...rows, id: \.self) { row in
+                    KeyContainer(model: model,
+                                 pitch: Pitch(intValue: pitch.intValue + ((rows-row) * 5)),
+                                 latching: latching,
+                                 layout: .guitar,
+                                 content: content)
+                    }
+                }
             }
         }
         .frame(minWidth: 100, minHeight: 100)
@@ -132,12 +157,14 @@ extension Keyboard where Content == KeyboardKey {
                 latching: Bool = false,
                 layout: KeyboardLayout = .piano,
                 noteOn: @escaping (Pitch) -> Void = { _ in },
-                noteOff: @escaping (Pitch) -> Void = { _ in }) {
+                noteOff: @escaping (Pitch) -> Void = { _ in },
+                rows: Int = 6){
         self.pitchRange = pitchRange
         self.latching = latching
         self.layout = layout
         self.noteOn = noteOn
         self.noteOff = noteOff
+        self.rows = rows
         self.content = { KeyboardKey(pitch: $0, isActivated: $1, flatTop: layout == .piano) }
     }
 

--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -79,7 +79,7 @@ public struct Keyboard<Content>: View where Content: View {
         HStack(spacing: 0) {
             ForEach(pitchRange, id: \.self) { pitch in
                 VStack(spacing: 0){
-                    ForEach(0...rows, id: \.self) { row in
+                    ForEach(1...rows, id: \.self) { row in
                     KeyContainer(model: model,
                                  pitch: Pitch(intValue: pitch.intValue + ((rows-row) * 5)),
                                  latching: latching,

--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -10,22 +10,22 @@ public struct Keyboard<Content>: View where Content: View {
     var latching: Bool
     var noteOn: (Pitch) -> Void
     var noteOff: (Pitch) -> Void
-    var rows: Int
+    var rowCount: Int
     var layout: KeyboardLayout
 
     public init(pitchRange: ClosedRange<Pitch> = (Pitch(60)...Pitch(72)),
                 latching: Bool = false,
                 layout: KeyboardLayout = .piano,
+                rowCount: Int = 6,
                 noteOn: @escaping (Pitch) -> Void = { _ in },
                 noteOff: @escaping (Pitch) -> Void = { _ in },
-                rows: Int = 6,
                 @ViewBuilder content: @escaping (Pitch, Bool)->Content) {
         self.pitchRange = pitchRange
         self.latching = latching
         self.layout = layout
         self.noteOn = noteOn
         self.noteOff = noteOff
-        self.rows = rows
+        self.rowCount = rowCount
         self.content = content
     }
 
@@ -79,9 +79,9 @@ public struct Keyboard<Content>: View where Content: View {
         HStack(spacing: 0) {
             ForEach(pitchRange, id: \.self) { pitch in
                 VStack(spacing: 0){
-                    ForEach(1...rows, id: \.self) { row in
+                    ForEach(1...rowCount, id: \.self) { row in
                     KeyContainer(model: model,
-                                 pitch: Pitch(intValue: pitch.intValue + ((rows-row) * 5)),
+                                 pitch: Pitch(intValue: pitch.intValue + ((rowCount-row) * 5)),
                                  latching: latching,
                                  layout: .guitar,
                                  content: content)
@@ -156,15 +156,15 @@ extension Keyboard where Content == KeyboardKey {
     public init(pitchRange: ClosedRange<Pitch> = (Pitch(60)...Pitch(72)),
                 latching: Bool = false,
                 layout: KeyboardLayout = .piano,
+                rowCount: Int = 6,
                 noteOn: @escaping (Pitch) -> Void = { _ in },
-                noteOff: @escaping (Pitch) -> Void = { _ in },
-                rows: Int = 6){
+                noteOff: @escaping (Pitch) -> Void = { _ in }){
         self.pitchRange = pitchRange
         self.latching = latching
         self.layout = layout
+        self.rowCount = rowCount
         self.noteOn = noteOn
         self.noteOff = noteOff
-        self.rows = rows
         self.content = { KeyboardKey(pitch: $0, isActivated: $1, flatTop: layout == .piano) }
     }
 

--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -10,13 +10,12 @@ public struct Keyboard<Content>: View where Content: View {
     var latching: Bool
     var noteOn: (Pitch) -> Void
     var noteOff: (Pitch) -> Void
-    var rowCount: Int
+    var rowCount: Int = 1
     var layout: KeyboardLayout
 
     public init(pitchRange: ClosedRange<Pitch> = (Pitch(60)...Pitch(72)),
                 latching: Bool = false,
                 layout: KeyboardLayout = .piano,
-                rowCount: Int = 6,
                 noteOn: @escaping (Pitch) -> Void = { _ in },
                 noteOff: @escaping (Pitch) -> Void = { _ in },
                 @ViewBuilder content: @escaping (Pitch, Bool)->Content) {
@@ -25,7 +24,6 @@ public struct Keyboard<Content>: View where Content: View {
         self.layout = layout
         self.noteOn = noteOn
         self.noteOff = noteOff
-        self.rowCount = rowCount
         self.content = content
     }
 
@@ -83,7 +81,7 @@ public struct Keyboard<Content>: View where Content: View {
                     KeyContainer(model: model,
                                  pitch: Pitch(intValue: pitch.intValue + ((rowCount-row) * 5)),
                                  latching: latching,
-                                 layout: .guitar,
+                                 layout: .guitar(rowCount: rowCount),
                                  content: content)
                     }
                 }
@@ -156,18 +154,21 @@ extension Keyboard where Content == KeyboardKey {
     public init(pitchRange: ClosedRange<Pitch> = (Pitch(60)...Pitch(72)),
                 latching: Bool = false,
                 layout: KeyboardLayout = .piano,
-                rowCount: Int = 6,
                 noteOn: @escaping (Pitch) -> Void = { _ in },
                 noteOff: @escaping (Pitch) -> Void = { _ in }){
         self.pitchRange = pitchRange
         self.latching = latching
         self.layout = layout
-        self.rowCount = rowCount
         self.noteOn = noteOn
         self.noteOff = noteOff
+        switch layout {
+        case .guitar(let row):
+            self.rowCount = row
+        default:
+            self.rowCount = 1
+        }
         self.content = { KeyboardKey(pitch: $0, isActivated: $1, flatTop: layout == .piano) }
     }
-
 }
 
 struct Keyboard_Previews: PreviewProvider {

--- a/Sources/Keyboard/KeyboardKey.swift
+++ b/Sources/Keyboard/KeyboardKey.swift
@@ -84,10 +84,10 @@ public struct KeyboardKey: View {
             ZStack(alignment: proxy.size.height > proxy.size.width ? .bottom : .trailing) {
                 Rectangle()
                     .foregroundColor(keyColor)
-                    .padding(.trailing, 1)
-                    .padding(.top, flatTop ? relativeCornerRadius(in: proxy.size) : 1)
+                    .padding(.top, flatTop ? relativeCornerRadius(in: proxy.size) : 0)
                     .cornerRadius(relativeCornerRadius(in: proxy.size))
-                    .padding(.top, flatTop ? -relativeCornerRadius(in: proxy.size): 0)
+                    .padding(.top, flatTop ? -relativeCornerRadius(in: proxy.size): 1)
+                    .padding(.trailing, 1)
                 Text(text)
                     .font(Font(.init(.system, size: relativeFontSize(in: proxy.size))))
                     .foregroundColor(textColor)

--- a/Sources/Keyboard/KeyboardLayout.swift
+++ b/Sources/Keyboard/KeyboardLayout.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Types of keyboards we can generate
-public enum KeyboardLayout {
+public enum KeyboardLayout: Equatable, Hashable  {
     /// Traditional Piano layout with raised black keys over white keys
     case piano
     
@@ -9,7 +9,7 @@ public enum KeyboardLayout {
     case isomorphic
     
     /// Notes in 4ths layout with rows and columns
-    case guitar
+    case guitar(rowCount: Int)
 
     /// Vertical isomorphic
     case pianoRoll

--- a/Sources/Keyboard/KeyboardLayout.swift
+++ b/Sources/Keyboard/KeyboardLayout.swift
@@ -5,8 +5,11 @@ public enum KeyboardLayout {
     /// Traditional Piano layout with raised black keys over white keys
     case piano
     
-    /// All notes linearly right afater one another
+    /// All notes linearly right after one another
     case isomorphic
+    
+    /// Notes in 4ths layout with rows and columns
+    case guitar
 
     /// Vertical isomorphic
     case pianoRoll


### PR DESCRIPTION
This PR adds a guitar layout that is tuned to 4ths. It is basically the isometric keyboard with each row (string) offset by 5 notes. I added an example to the demo.

This does add a "rows" variable to the Keyboard class for setting the number of strings. And the pitchRange is the range of notes only on the first row which could result in the higher strings' pitches being out of bounds if not calculated with this in mind.

It is just a starting point. Let me know what you think!