### PR TITLE
Export Tonic so consumer does not have to import it

### DIFF
--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import Tonic
+@_exported import Tonic
 
 /// Touch-oriented musical keyboard
 public struct Keyboard<Content>: View where Content: View {


### PR DESCRIPTION
Keyboard uses Tonic value types such as Pitch, which are not usable if the consumer only imports Keyboard. It is not obvious that Tonic must also be imported to use them and throws an ambiguous error.
Exporting Tonic allows Tonic's value types to be used while only needing to import Keyboard.