### PR TITLE
Fix Stuck Keys

### DIFF
--- a/Sources/Keyboard/KeyContainer.swift
+++ b/Sources/Keyboard/KeyContainer.swift
@@ -32,16 +32,7 @@ public struct KeyContainer<Content: View>: View {
 
     func rect(rect: CGRect) -> some View {
         content(pitch, model.touchedPitches.contains(pitch) || model.externallyActivatedPitches.contains(pitch))
-            .contentShape(Rectangle()) // Added to improve tap/click reliability
-            .gesture(
-                TapGesture().onEnded { _ in
-                    if model.externallyActivatedPitches.contains(pitch) {
-                        model.externallyActivatedPitches.remove(pitch)
-                    } else {
-                        model.externallyActivatedPitches.add(pitch)
-                    }
-                }
-            )
+            .contentShape(Rectangle())
             .preference(key: KeyRectsKey.self,
                         value: [KeyRectInfo(rect: rect,
                                             pitch: pitch,

--- a/Sources/Keyboard/KeyContainer.swift
+++ b/Sources/Keyboard/KeyContainer.swift
@@ -32,13 +32,15 @@ public struct KeyContainer<Content: View>: View {
 
     func rect(rect: CGRect) -> some View {
         content(pitch, model.touchedPitches.contains(pitch) || model.externallyActivatedPitches.contains(pitch))
-            .contentShape(Rectangle()) // Added to improve tap/click reliability
+            .contentShape(Rectangle())
             .gesture(
                 TapGesture().onEnded { _ in
-                    if model.externallyActivatedPitches.contains(pitch) {
-                        model.externallyActivatedPitches.remove(pitch)
-                    } else {
-                        model.externallyActivatedPitches.add(pitch)
+                    if model.latching {
+                        if model.externallyActivatedPitches.contains(pitch) {
+                            model.externallyActivatedPitches.remove(pitch)
+                        } else {
+                            model.externallyActivatedPitches.add(pitch)
+                        }
                     }
                 }
             )

--- a/Sources/Keyboard/KeyContainer.swift
+++ b/Sources/Keyboard/KeyContainer.swift
@@ -32,7 +32,16 @@ public struct KeyContainer<Content: View>: View {
 
     func rect(rect: CGRect) -> some View {
         content(pitch, model.touchedPitches.contains(pitch) || model.externallyActivatedPitches.contains(pitch))
-            .contentShape(Rectangle())
+            .contentShape(Rectangle()) // Added to improve tap/click reliability
+            .gesture(
+                TapGesture().onEnded { _ in
+                    if model.externallyActivatedPitches.contains(pitch) {
+                        model.externallyActivatedPitches.remove(pitch)
+                    } else {
+                        model.externallyActivatedPitches.add(pitch)
+                    }
+                }
+            )
             .preference(key: KeyRectsKey.self,
                         value: [KeyRectInfo(rect: rect,
                                             pitch: pitch,

--- a/Sources/Keyboard/Keyboard.swift
+++ b/Sources/Keyboard/Keyboard.swift
@@ -81,6 +81,7 @@ public struct Keyboard<Content>: View where Content: View {
         }.onAppear {
             model.noteOn = noteOn
             model.noteOff = noteOff
+            model.latching = latching
         }
     }
 }

--- a/Sources/Keyboard/KeyboardModel.swift
+++ b/Sources/Keyboard/KeyboardModel.swift
@@ -9,6 +9,7 @@ public class KeyboardModel: ObservableObject {
     var noteOn: (Pitch, CGPoint) -> Void = { _, _ in }
     var noteOff: (Pitch) -> Void = { _ in }
     var normalizedPoints = Array(repeating: CGPoint.zero, count: 128)
+    var latching: Bool = false
 
     var touchLocations: [CGPoint] = [] {
         didSet {


### PR DESCRIPTION
This fixes the stuck key issue on key edge taps. It appears we had an external trigger for notes on and off that wasn't an issue until iOS 18.

@aure I'm not sure if this change affects anything you are working with, but it fixed my issue.